### PR TITLE
Add pl translation for new strings

### DIFF
--- a/values-pl/strings.xml
+++ b/values-pl/strings.xml
@@ -266,7 +266,7 @@
     <string name="summary_device_info">Informacje o tym urządzeniu</string>
     <string name="title_pref_devicesettings_devinfo_hwrev">Wersja sprzętu</string>
     <string name="title_pref_devicesettings_devinfo_swrev">Wersja oprogramowania</string>
-    <string name="title_pref_devicesettings_devinfo_fwrev">Oprgoramowanie sprzętowe</string>
+    <string name="title_pref_devicesettings_devinfo_fwrev">Oprogramowanie sprzętowe</string>
     <string name="title_pref_devicesettings_devinfo_serial">Numer Seryjny</string>
     <string name="title_pref_devicesettings_devinfo_model">Numer modelu</string>
     <string name="title_pref_devicesettings_devinfo_manufacturer">Producent</string>

--- a/values-pl/strings.xml
+++ b/values-pl/strings.xml
@@ -260,7 +260,16 @@
     <string name="summary_pref_filter">Tylko znane urządzenia (w przypadku problemów, crashowania itp.)</string>
     <string name="moisture">Wilgoć</string>
     <string name="illuminance">Intensywność światła</string>
-    <string name="conductivity">Fertility</string>
+    <string name="conductivity">Przewodnictwo</string>
+    <string name="title_pref_devicesettings_devinfo">Informacje o urządzeniu</string>
+    <string name="loading">Ładowanie. Proszę czekać…</string>
+    <string name="summary_device_info">Informacje o tym urządzeniu</string>
+    <string name="title_pref_devicesettings_devinfo_hwrev">Wersja sprzętu</string>
+    <string name="title_pref_devicesettings_devinfo_swrev">Wersja oprogramowania</string>
+    <string name="title_pref_devicesettings_devinfo_fwrev">Oprgoramowanie sprzętowe</string>
+    <string name="title_pref_devicesettings_devinfo_serial">Numer Seryjny</string>
+    <string name="title_pref_devicesettings_devinfo_model">Numer modelu</string>
+    <string name="title_pref_devicesettings_devinfo_manufacturer">Producent</string>
 
 
     <!--string name="thingspeak_help2">


### PR DESCRIPTION
Added missing Polish translations.

I'm not sure about
```
<string name="conductivity">Fertility</string>
```
Translated label `conductivity`. It would be helpful to have some more context where it is used (maybe screenshot).

For `title_pref_devicesettings_devinfo_fwrev` tried to make it short: `Oprogramowanie sprzętowe`, but if there is more place in the UI it could be `Wersja oprogramowania sprzętowego`.